### PR TITLE
Added priority notification on Host Down

### DIFF
--- a/notify-by-pushover.php
+++ b/notify-by-pushover.php
@@ -97,6 +97,7 @@ switch( $state )
         $priority = PO_PRI_NORMAL;
         break;
 
+   case 'DOWN':
    case 'CRITICAL':
         $priority = PO_PRI_HIGH;
         break;


### PR DESCRIPTION
The state sent by Nagios on a host being down using the `check-host-alive` command is 'DOWN' instead of critical, this caused our monitoring service to not send the pushovers as priority when a host is down. This is my proposed solution.
