### PR TITLE
Update notify-by-pushover.php

### DIFF
--- a/notify-by-pushover.php
+++ b/notify-by-pushover.php
@@ -99,8 +99,13 @@ switch( $state )
 
    case 'DOWN':
    case 'CRITICAL':
-        $priority = PO_PRI_HIGH;
-        break;
+        if ($type == "ACKNOWLEDGEMENT") {
+           $priority = PO_PRI_NORMAL;
+        } else {
+           $priority = PO_PRI_HIGH;
+        }
+	break;
+
 
     default:
         $priority = PO_PRI_NORMAL;


### PR DESCRIPTION
The system was sending out priority notifications on ACKNOWLEDGEMENT which in our case means a high-pitched alarm even when the phone is silent. Since the goal of ack is to stop receiving alerts about a service we figured a normal pushover would be sufficient in that specific case.
